### PR TITLE
feat(public profile):: load profile did document for failed public pr…

### DIFF
--- a/src/helpers/VeridaHelper.ts
+++ b/src/helpers/VeridaHelper.ts
@@ -53,7 +53,6 @@ class VeridaHelper extends EventEmitter {
       VUE_APP_VAULT_CONTEXT_NAME,
       "basicProfile"
     );
-
     if (profileInstance) {
       this.profile = await profileInstance.getMany({}, {});
       if (this.profile) {
@@ -141,9 +140,6 @@ class VeridaHelper extends EventEmitter {
     );
     const didDocument = await didClient.get(did);
     const doc = didDocument?.export();
-
-    console.log(doc);
-
     this.didDocument = doc;
   }
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import veridaHelper from "@/helpers/VeridaHelper";
 import { createStore } from "vuex";
 
@@ -34,11 +35,21 @@ export default createStore({
     async fetchProfile({ commit }, did: string) {
       commit("setLoader", true);
       try {
-        await veridaHelper.getProfile(did);
         await veridaHelper.getDidDocument(did);
+        await veridaHelper.getProfile(did);
         commit("setProfile", veridaHelper.profile);
-      } catch (error) {
-        commit("setError", "DID not found");
+      } catch (error: any) {
+        // Check if DID document was found
+        if (veridaHelper.didDocument) {
+          commit("setProfile", {
+            name: "unknown",
+            avatar: { uri: "" },
+            country: "",
+            did,
+          });
+        } else {
+          commit("setError", error.message);
+        }
       }
     },
   },


### PR DESCRIPTION

I checked if the public profile `didDocument` exists when it failed to fetch the profile of an old account then load the profile name with `unknown` and update the `didDocument` so it could be displayed on the UI.

### Demo

https://www.loom.com/share/2283c1ebc12146f28cccd9631e5de7a8

#130